### PR TITLE
[Refactor] Moves header responsibility to response

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,6 +10,7 @@ repositories {
 dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
     testImplementation 'org.mockito:mockito-core:3.+'
+    testImplementation 'org.hamcrest:hamcrest:2.2'
 
     implementation 'com.google.guava:guava:30.1.1-jre'
 }

--- a/app/src/main/java/ikarabulut/http/handlers/GetRequestHandler.java
+++ b/app/src/main/java/ikarabulut/http/handlers/GetRequestHandler.java
@@ -8,17 +8,10 @@ import java.util.*;
 
 public class GetRequestHandler implements RequestHandler {
     private Map<String, String> initialLine;
-    private Map<String, String> headers;
     private String body;
 
     public GetRequestHandler(Map<String, String> initialLine) {
         this.initialLine = initialLine;
-        this.headers = new HashMap<>() {
-            {
-                put("Date", new Date().toString());
-                put("Content-Language", "en-US");
-            }
-        };
         this.body = "Hello world";
     }
 
@@ -26,14 +19,12 @@ public class GetRequestHandler implements RequestHandler {
     public Response processResponse() {
         String version = initialLine.get("httpVersion");
         StatusCode status = StatusCode.OK;
-        String statusCode = status.getStatusCode();
-        String statusNumber = status.getStatusNumber();
 
         Response getResponse;
         if (initialLine.get("httpPath").equals("/simple_get_with_body")) {
-            getResponse = new GetResponse(version, status, headers, body);
+            getResponse = new GetResponse(version, status, body);
         } else {
-            getResponse = new GetResponse(version, status, headers);
+            getResponse = new GetResponse(version, status);
         }
 
         return getResponse;

--- a/app/src/main/java/ikarabulut/http/handlers/GetRequestHandler.java
+++ b/app/src/main/java/ikarabulut/http/handlers/GetRequestHandler.java
@@ -6,7 +6,7 @@ import ikarabulut.http.response.StatusCode;
 
 import java.util.*;
 
-public class GetRequestHandler {
+public class GetRequestHandler implements RequestHandler {
     private Map<String, String> initialLine;
     private Map<String, String> headers;
     private String body;
@@ -22,6 +22,7 @@ public class GetRequestHandler {
         this.body = "Hello world";
     }
 
+    @Override
     public Response processResponse() {
         String version = initialLine.get("httpVersion");
         StatusCode statusCode = StatusCode.OK;

--- a/app/src/main/java/ikarabulut/http/handlers/GetRequestHandler.java
+++ b/app/src/main/java/ikarabulut/http/handlers/GetRequestHandler.java
@@ -25,14 +25,15 @@ public class GetRequestHandler implements RequestHandler {
     @Override
     public Response processResponse() {
         String version = initialLine.get("httpVersion");
-        StatusCode statusCode = StatusCode.OK;
-        String statusNumber = statusCode.getStatusNumber();
+        StatusCode status = StatusCode.OK;
+        String statusCode = status.getStatusCode();
+        String statusNumber = status.getStatusNumber();
 
         Response getResponse;
         if (initialLine.get("httpPath").equals("/simple_get_with_body")) {
-            getResponse = new GetResponse(version, statusCode, statusNumber, headers, body);
+            getResponse = new GetResponse(version, status, headers, body);
         } else {
-            getResponse = new GetResponse(version, statusCode, statusNumber, headers);
+            getResponse = new GetResponse(version, status, headers);
         }
 
         return getResponse;

--- a/app/src/main/java/ikarabulut/http/handlers/HeadRequestHandler.java
+++ b/app/src/main/java/ikarabulut/http/handlers/HeadRequestHandler.java
@@ -23,9 +23,8 @@ public class HeadRequestHandler implements RequestHandler {
     @Override
     public Response processResponse() {
         String version = initialLine.get("httpVersion");
-        StatusCode statusCode = StatusCode.OK;
-        String statusNumber = statusCode.getStatusNumber();
-        return new HeadResponse(version, statusCode, statusNumber, headers);
+        StatusCode status = StatusCode.OK;
+        return new HeadResponse(version, status, headers);
     }
 
 

--- a/app/src/main/java/ikarabulut/http/handlers/HeadRequestHandler.java
+++ b/app/src/main/java/ikarabulut/http/handlers/HeadRequestHandler.java
@@ -8,23 +8,16 @@ import java.util.*;
 
 public class HeadRequestHandler implements RequestHandler {
     Map<String, String> initialLine;
-    Map<String, String> headers;
 
     public HeadRequestHandler(Map<String, String> initialLine) {
         this.initialLine = initialLine;
-        this.headers = new HashMap<>() {
-            {
-                put("Date", new Date().toString());
-                put("Content-Language", "en-US");
-            }
-        };
     }
 
     @Override
     public Response processResponse() {
         String version = initialLine.get("httpVersion");
         StatusCode status = StatusCode.OK;
-        return new HeadResponse(version, status, headers);
+        return new HeadResponse(version, status);
     }
 
 

--- a/app/src/main/java/ikarabulut/http/handlers/HeadRequestHandler.java
+++ b/app/src/main/java/ikarabulut/http/handlers/HeadRequestHandler.java
@@ -6,7 +6,7 @@ import ikarabulut.http.response.StatusCode;
 
 import java.util.*;
 
-public class HeadRequestHandler {
+public class HeadRequestHandler implements RequestHandler {
     Map<String, String> initialLine;
     Map<String, String> headers;
 
@@ -20,6 +20,7 @@ public class HeadRequestHandler {
         };
     }
 
+    @Override
     public Response processResponse() {
         String version = initialLine.get("httpVersion");
         StatusCode statusCode = StatusCode.OK;

--- a/app/src/main/java/ikarabulut/http/handlers/MethodNotAllowedHandler.java
+++ b/app/src/main/java/ikarabulut/http/handlers/MethodNotAllowedHandler.java
@@ -17,7 +17,7 @@ public class MethodNotAllowedHandler {
         this.initialLine = initialLine;
     }
 
-    public Map<String, String> generateAllowHeaders() {
+    public Map<String, String> generateHeaders() {
         Map<String, String> allowHeader = new HashMap<>() {{
             put("Allow", "HEAD, OPTIONS");
         }};
@@ -28,7 +28,7 @@ public class MethodNotAllowedHandler {
         String version = initialLine.get("httpVersion");
         String statusCode = StatusCode.NOT_ALLOWED.getStatusCode();
         String statusNumber = StatusCode.NOT_ALLOWED.getStatusNumber();
-        Map<String, String> headers = generateAllowHeaders();
+        Map<String, String> headers = generateHeaders();
 
         Response response = new MethodNotAllowedResponse(version, statusCode, statusNumber, headers);
 

--- a/app/src/main/java/ikarabulut/http/handlers/MethodNotAllowedHandler.java
+++ b/app/src/main/java/ikarabulut/http/handlers/MethodNotAllowedHandler.java
@@ -18,20 +18,11 @@ public class MethodNotAllowedHandler {
         this.initialLine = initialLine;
     }
 
-    public Map<String, String> generateHeaders() {
-        Map<String, String> allowHeader = new HashMap<>() {{
-            put("Allow", "HEAD, OPTIONS");
-        }};
-        return allowHeader;
-    }
-
     public Response processResponse() {
         String version = initialLine.get("httpVersion");
         StatusCode status = StatusCode.NOT_ALLOWED;
 
-        Map<String, String> headers = generateHeaders();
-
-        Response response = new MethodNotAllowedResponse(version, status, headers);
+        Response response = new MethodNotAllowedResponse(version, status);
 
         return response;
     }

--- a/app/src/main/java/ikarabulut/http/handlers/MethodNotAllowedHandler.java
+++ b/app/src/main/java/ikarabulut/http/handlers/MethodNotAllowedHandler.java
@@ -3,6 +3,7 @@ package ikarabulut.http.handlers;
 import ikarabulut.http.response.MethodNotAllowedResponse;
 import ikarabulut.http.response.Response;
 import ikarabulut.http.response.StatusCode;
+import jdk.jshell.Snippet;
 
 import java.util.HashMap;
 import java.util.List;
@@ -26,11 +27,11 @@ public class MethodNotAllowedHandler {
 
     public Response processResponse() {
         String version = initialLine.get("httpVersion");
-        String statusCode = StatusCode.NOT_ALLOWED.getStatusCode();
-        String statusNumber = StatusCode.NOT_ALLOWED.getStatusNumber();
+        StatusCode status = StatusCode.NOT_ALLOWED;
+
         Map<String, String> headers = generateHeaders();
 
-        Response response = new MethodNotAllowedResponse(version, statusCode, statusNumber, headers);
+        Response response = new MethodNotAllowedResponse(version, status, headers);
 
         return response;
     }

--- a/app/src/main/java/ikarabulut/http/handlers/RequestHandler.java
+++ b/app/src/main/java/ikarabulut/http/handlers/RequestHandler.java
@@ -2,6 +2,10 @@ package ikarabulut.http.handlers;
 
 import ikarabulut.http.response.Response;
 
+import java.util.Map;
+
 public interface RequestHandler {
     Response processResponse();
+
+//    Map<String, String> generateHeaders();
 }

--- a/app/src/main/java/ikarabulut/http/handlers/RequestHandler.java
+++ b/app/src/main/java/ikarabulut/http/handlers/RequestHandler.java
@@ -7,5 +7,4 @@ import java.util.Map;
 public interface RequestHandler {
     Response processResponse();
 
-//    Map<String, String> generateHeaders();
 }

--- a/app/src/main/java/ikarabulut/http/response/GetResponse.java
+++ b/app/src/main/java/ikarabulut/http/response/GetResponse.java
@@ -3,10 +3,10 @@ package ikarabulut.http.response;
 import java.util.Map;
 
 public class GetResponse implements Response {
-    protected final String version;
-    protected final StatusCode status;
-    protected final Map<String, String> headers;
-    protected String body;
+    private final String version;
+    private final StatusCode status;
+    private final Map<String, String> headers;
+    private String body;
 
     public GetResponse(String version, StatusCode status, Map<String, String> headers) {
         this(version, status, headers, EMPTYBODY);

--- a/app/src/main/java/ikarabulut/http/response/GetResponse.java
+++ b/app/src/main/java/ikarabulut/http/response/GetResponse.java
@@ -1,11 +1,13 @@
 package ikarabulut.http.response;
 
+import java.util.Date;
+import java.util.HashMap;
 import java.util.Map;
 
 public class GetResponse implements Response {
     private final String version;
     private final StatusCode status;
-    private final Map<String, String> headers;
+    private Map<String, String> headers;
     private String body;
 
     public GetResponse(String version, StatusCode status, Map<String, String> headers) {
@@ -17,6 +19,23 @@ public class GetResponse implements Response {
         this.status = status;
         this.headers = headers;
         this.body = body;
+    }
+    public GetResponse(String version, StatusCode status) {
+        this(version, status,EMPTYBODY);
+    }
+
+    public GetResponse(String version, StatusCode status, String body) {
+        this.version = version;
+        this.status = status;
+        this.body = body;
+    }
+
+    public Map<String, String> generateHeaders() {
+        headers = new HashMap<>() {{
+            put("Date", new Date().toString());
+            put("Content-Language", "en-US");
+        }};
+        return headers;
     }
 
     @Override
@@ -35,6 +54,8 @@ public class GetResponse implements Response {
     }
 
     private String stringifyHeaders() {
+        generateHeaders();
+
         StringBuilder headersAsAString = new StringBuilder();
         for (Map.Entry<String, String> set : headers.entrySet()) {
             headersAsAString.append(set.getKey()).append(": ").append(set.getValue()).append(CRLF);

--- a/app/src/main/java/ikarabulut/http/response/GetResponse.java
+++ b/app/src/main/java/ikarabulut/http/response/GetResponse.java
@@ -10,16 +10,6 @@ public class GetResponse implements Response {
     private Map<String, String> headers;
     private String body;
 
-    public GetResponse(String version, StatusCode status, Map<String, String> headers) {
-        this(version, status, headers, EMPTYBODY);
-    }
-
-    public GetResponse(String version, StatusCode status, Map<String, String> headers, String body) {
-        this.version = version;
-        this.status = status;
-        this.headers = headers;
-        this.body = body;
-    }
     public GetResponse(String version, StatusCode status) {
         this(version, status,EMPTYBODY);
     }

--- a/app/src/main/java/ikarabulut/http/response/GetResponse.java
+++ b/app/src/main/java/ikarabulut/http/response/GetResponse.java
@@ -4,25 +4,26 @@ import java.util.Map;
 
 public class GetResponse implements Response {
     protected final String version;
-    protected final StatusCode statusCode;
-    protected final String statusNumber;
+    protected final StatusCode status;
     protected final Map<String, String> headers;
     protected String body;
 
-    public GetResponse(String version, StatusCode statusCode, String statusNumber, Map<String, String> headers) {
-        this(version, statusCode, statusNumber, headers, EMPTYBODY);
+    public GetResponse(String version, StatusCode status, Map<String, String> headers) {
+        this(version, status, headers, EMPTYBODY);
     }
 
-    public GetResponse(String version, StatusCode statusCode, String statusNumber, Map<String, String> headers, String body) {
+    public GetResponse(String version, StatusCode status, Map<String, String> headers, String body) {
         this.version = version;
-        this.statusCode = statusCode;
-        this.statusNumber = statusNumber;
+        this.status = status;
         this.headers = headers;
         this.body = body;
     }
 
     @Override
     public String stringifyResponse() {
+        String statusCode = status.getStatusCode();
+        String statusNumber = status.getStatusNumber();
+
         String initialLine = version + SPACE + statusNumber + SPACE + statusCode + CRLF;
         String headers = stringifyHeaders();
 

--- a/app/src/main/java/ikarabulut/http/response/HeadResponse.java
+++ b/app/src/main/java/ikarabulut/http/response/HeadResponse.java
@@ -4,19 +4,20 @@ import java.util.Map;
 
 public class HeadResponse implements Response {
     protected final String version;
-    protected final StatusCode statusCode;
-    protected final String statusNumber;
+    protected final StatusCode status;
     protected final Map<String, String> headers;
 
-    public HeadResponse(String version, StatusCode statusCode, String statusNumber, Map<String, String> headers) {
+    public HeadResponse(String version, StatusCode status, Map<String, String> headers) {
         this.version = version;
-        this.statusCode = statusCode;
-        this.statusNumber = statusNumber;
+        this.status = status;
         this.headers = headers;
     }
 
     @Override
     public String stringifyResponse() {
+        String statusNumber = status.getStatusNumber();
+        String statusCode = status.getStatusCode();
+
         String initialLine = version + SPACE + statusNumber + SPACE + statusCode + CRLF;
         String headers = stringifyHeaders();
 

--- a/app/src/main/java/ikarabulut/http/response/HeadResponse.java
+++ b/app/src/main/java/ikarabulut/http/response/HeadResponse.java
@@ -3,9 +3,9 @@ package ikarabulut.http.response;
 import java.util.Map;
 
 public class HeadResponse implements Response {
-    protected final String version;
-    protected final StatusCode status;
-    protected final Map<String, String> headers;
+    private final String version;
+    private final StatusCode status;
+    private final Map<String, String> headers;
 
     public HeadResponse(String version, StatusCode status, Map<String, String> headers) {
         this.version = version;

--- a/app/src/main/java/ikarabulut/http/response/HeadResponse.java
+++ b/app/src/main/java/ikarabulut/http/response/HeadResponse.java
@@ -1,21 +1,26 @@
 package ikarabulut.http.response;
 
+import java.util.Date;
+import java.util.HashMap;
 import java.util.Map;
 
 public class HeadResponse implements Response {
     private final String version;
     private final StatusCode status;
-    private final Map<String, String> headers;
+    private Map<String, String> headers;
 
-    public HeadResponse(String version, StatusCode status, Map<String, String> headers) {
+    public HeadResponse(String version, StatusCode status) {
         this.version = version;
         this.status = status;
-        this.headers = headers;
     }
 
     @Override
     public Map<String, String> generateHeaders() {
-        return null; //TEMP
+        headers = new HashMap<>() {{
+            put("Date", new Date().toString());
+            put("Content-Language", "en-US");
+        }};
+        return headers;
     }
 
     @Override
@@ -35,6 +40,8 @@ public class HeadResponse implements Response {
     }
 
     private String stringifyHeaders() {
+        generateHeaders();
+
         StringBuilder headersAsAString = new StringBuilder();
         for (Map.Entry<String, String> set : headers.entrySet()) {
             headersAsAString.append(set.getKey()).append(": ").append(set.getValue()).append(CRLF);

--- a/app/src/main/java/ikarabulut/http/response/HeadResponse.java
+++ b/app/src/main/java/ikarabulut/http/response/HeadResponse.java
@@ -14,6 +14,11 @@ public class HeadResponse implements Response {
     }
 
     @Override
+    public Map<String, String> generateHeaders() {
+        return null; //TEMP
+    }
+
+    @Override
     public String stringifyResponse() {
         String statusNumber = status.getStatusNumber();
         String statusCode = status.getStatusCode();

--- a/app/src/main/java/ikarabulut/http/response/MethodNotAllowedResponse.java
+++ b/app/src/main/java/ikarabulut/http/response/MethodNotAllowedResponse.java
@@ -3,10 +3,10 @@ package ikarabulut.http.response;
 import java.util.Map;
 
 public class MethodNotAllowedResponse implements Response {
-    protected final String version;
-    protected final StatusCode status;
-    protected final Map<String, String> headers;
-    protected final String body = EMPTYBODY;
+    private final String version;
+    private final StatusCode status;
+    private final Map<String, String> headers;
+    private final String body = EMPTYBODY;
 
     public MethodNotAllowedResponse(String version, StatusCode status, Map<String,String> headers) {
         this.version = version;

--- a/app/src/main/java/ikarabulut/http/response/MethodNotAllowedResponse.java
+++ b/app/src/main/java/ikarabulut/http/response/MethodNotAllowedResponse.java
@@ -1,22 +1,25 @@
 package ikarabulut.http.response;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class MethodNotAllowedResponse implements Response {
     private final String version;
     private final StatusCode status;
-    private final Map<String, String> headers;
+    private Map<String, String> headers;
     private final String body = EMPTYBODY;
 
-    public MethodNotAllowedResponse(String version, StatusCode status, Map<String,String> headers) {
+    public MethodNotAllowedResponse(String version, StatusCode status) {
         this.version = version;
         this.status = status;
-        this.headers = headers;
     }
 
     @Override
     public Map<String, String> generateHeaders() {
-        return null; //TEMP
+        headers = new HashMap<>() {{
+            put("Allow", "HEAD, OPTIONS");
+        }};
+        return headers;
     }
 
     @Override
@@ -36,6 +39,8 @@ public class MethodNotAllowedResponse implements Response {
     }
 
     private String stringifyHeaders() {
+        generateHeaders();
+
         StringBuilder headersAsAString = new StringBuilder();
         for (Map.Entry<String, String> set : headers.entrySet()) {
             headersAsAString.append(set.getKey()).append(": ").append(set.getValue()).append(CRLF);
@@ -43,4 +48,5 @@ public class MethodNotAllowedResponse implements Response {
         headersAsAString.append(CRLF);
         return headersAsAString.toString();
     }
+
 }

--- a/app/src/main/java/ikarabulut/http/response/MethodNotAllowedResponse.java
+++ b/app/src/main/java/ikarabulut/http/response/MethodNotAllowedResponse.java
@@ -4,20 +4,21 @@ import java.util.Map;
 
 public class MethodNotAllowedResponse implements Response {
     protected final String version;
-    protected final String statusCode;
-    protected final String statusNumber;
+    protected final StatusCode status;
     protected final Map<String, String> headers;
     protected final String body = EMPTYBODY;
 
-    public MethodNotAllowedResponse(String version, String statusCode, String statusNumber, Map<String,String> headers) {
+    public MethodNotAllowedResponse(String version, StatusCode status, Map<String,String> headers) {
         this.version = version;
-        this.statusCode = statusCode;
-        this.statusNumber = statusNumber;
+        this.status = status;
         this.headers = headers;
     }
 
     @Override
     public String stringifyResponse() {
+        String statusCode = status.getStatusCode();
+        String statusNumber = status.getStatusNumber();
+
         String initialLine = version + SPACE + statusNumber + SPACE + statusCode + CRLF;
         String headers = stringifyHeaders();
 

--- a/app/src/main/java/ikarabulut/http/response/MethodNotAllowedResponse.java
+++ b/app/src/main/java/ikarabulut/http/response/MethodNotAllowedResponse.java
@@ -15,6 +15,11 @@ public class MethodNotAllowedResponse implements Response {
     }
 
     @Override
+    public Map<String, String> generateHeaders() {
+        return null; //TEMP
+    }
+
+    @Override
     public String stringifyResponse() {
         String statusCode = status.getStatusCode();
         String statusNumber = status.getStatusNumber();

--- a/app/src/main/java/ikarabulut/http/response/Response.java
+++ b/app/src/main/java/ikarabulut/http/response/Response.java
@@ -1,12 +1,16 @@
 package ikarabulut.http.response;
 
 
+import java.util.Map;
+
 public interface Response {
     String CRLF = "\r\n";
     String SPACE = " ";
     String EMPTYBODY = "";
 
     String stringifyResponse();
+
+    Map<String, String> generateHeaders();
 
     boolean hasBody();
 

--- a/app/src/test/java/ikarabulut/http/handlers/MethodNotAllowedHandlerTest.java
+++ b/app/src/test/java/ikarabulut/http/handlers/MethodNotAllowedHandlerTest.java
@@ -23,7 +23,7 @@ class MethodNotAllowedHandlerTest {
 
         MethodNotAllowedHandler handler = new MethodNotAllowedHandler(allowedMethods, initialLine);
 
-        Map<String, String> generatedHeader = handler.generateAllowHeaders();
+        Map<String, String> generatedHeader = handler.generateHeaders();
 
         assertEquals(expectedHeader, generatedHeader);
     }

--- a/app/src/test/java/ikarabulut/http/handlers/MethodNotAllowedHandlerTest.java
+++ b/app/src/test/java/ikarabulut/http/handlers/MethodNotAllowedHandlerTest.java
@@ -9,23 +9,4 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class MethodNotAllowedHandlerTest {
 
-    private Map<String, String> initialLine = new HashMap<>(){{
-        put("httpMethod", "HEAD");
-        put("httpPath", "/simple_get");
-        put("httpVersion", "HTTP/1.1");
-    }};
-
-    @Test
-    @DisplayName(("MethodNotAllowedHandler should generate a header displaying the allowed methods"))
-    void generateHeaders() {
-        List<String> allowedMethods = new ArrayList<>(Arrays.asList("HEAD", "GET"));
-        Map<String, String> expectedHeader = new HashMap<>() {{ put("Allow", "HEAD, OPTIONS"); }};
-
-        MethodNotAllowedHandler handler = new MethodNotAllowedHandler(allowedMethods, initialLine);
-
-        Map<String, String> generatedHeader = handler.generateHeaders();
-
-        assertEquals(expectedHeader, generatedHeader);
-    }
-
 }

--- a/app/src/test/java/ikarabulut/http/response/GetResponseTest.java
+++ b/app/src/test/java/ikarabulut/http/response/GetResponseTest.java
@@ -11,8 +11,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class GetResponseTest {
     private String version = "HTTP/1.1";
-    private StatusCode statusCode = StatusCode.OK;
-    private String statusNumber = statusCode.getStatusNumber();
+    private StatusCode status = StatusCode.OK;
     private Map<String, String> headers = new HashMap<>() {
         {
             put("Date", new Date().toString());
@@ -24,12 +23,13 @@ class GetResponseTest {
     @DisplayName("A GetResponse with a body should return a string with a body when stringified")
     void stringifyResponse_WithBody() {
         String expectedBody = "Hello World";
-        String expectedResponse = version + " " + statusNumber + " " + statusCode + "\r\n" +
+        String statusNumber = status.getStatusNumber();
+        String expectedResponse = version + " " + statusNumber + " " + status + "\r\n" +
                 "Date: " + headers.get("Date") + "\r\n" +
                 "Content-Language: " + headers.get("Content-Language") + "\r\n" +
                 "\r\n" +
                 expectedBody;
-        GetResponse getResponse = new GetResponse(version, statusCode, statusNumber, headers, expectedBody);
+        GetResponse getResponse = new GetResponse(version, status, headers, expectedBody);
         String stringifiedResponse = getResponse.stringifyResponse();
 
         assertEquals(expectedResponse, stringifiedResponse);
@@ -38,10 +38,12 @@ class GetResponseTest {
     @Test
     @DisplayName("A GetResponse without a body should return a string without a body when stringified")
     void stringifyResponse_WithoutBody() {
+        String statusCode = status.getStatusCode();
+        String statusNumber = status.getStatusNumber();
         String expectedResponse = version + " " + statusNumber + " " + statusCode + "\r\n" +
                 "Date: " + headers.get("Date") + "\r\n" +
                 "Content-Language: " + headers.get("Content-Language") + "\r\n" + "\r\n";
-        GetResponse getResponse = new GetResponse(version, statusCode, statusNumber, headers);
+        GetResponse getResponse = new GetResponse(version, status, headers);
 
         String stringifiedResponse = getResponse.stringifyResponse();
 

--- a/app/src/test/java/ikarabulut/http/response/GetResponseTest.java
+++ b/app/src/test/java/ikarabulut/http/response/GetResponseTest.java
@@ -29,7 +29,7 @@ class GetResponseTest {
                 "Content-Language: " + headers.get("Content-Language") + "\r\n" +
                 "\r\n" +
                 expectedBody;
-        GetResponse getResponse = new GetResponse(version, status, headers, expectedBody);
+        GetResponse getResponse = new GetResponse(version, status, expectedBody);
         String stringifiedResponse = getResponse.stringifyResponse();
 
         assertEquals(expectedResponse, stringifiedResponse);
@@ -43,7 +43,7 @@ class GetResponseTest {
         String expectedResponse = version + " " + statusNumber + " " + statusCode + "\r\n" +
                 "Date: " + headers.get("Date") + "\r\n" +
                 "Content-Language: " + headers.get("Content-Language") + "\r\n" + "\r\n";
-        GetResponse getResponse = new GetResponse(version, status, headers);
+        GetResponse getResponse = new GetResponse(version, status);
 
         String stringifiedResponse = getResponse.stringifyResponse();
 

--- a/app/src/test/java/ikarabulut/http/response/GetResponseTest.java
+++ b/app/src/test/java/ikarabulut/http/response/GetResponseTest.java
@@ -50,4 +50,17 @@ class GetResponseTest {
         assertEquals(expectedResponse, stringifiedResponse);
     }
 
+    @Test
+    @DisplayName("A Header should be generated with at minimum the date")
+    void generateHeaders_DefaultDate() {
+        Map<String,String> defaultHeader = new HashMap<>() {{
+                put("Date", new Date().toString());
+            }};
+        Response response = new GetResponse(version, status);
+
+        Map<String, String> generatedHeaders = response.generateHeaders();
+
+        assertTrue(generatedHeaders.containsKey("Date"));
+    }
+
 }

--- a/app/src/test/java/ikarabulut/http/response/HeadResponseTest.java
+++ b/app/src/test/java/ikarabulut/http/response/HeadResponseTest.java
@@ -29,11 +29,24 @@ class HeadResponseTest {
                 "Date: " + headers.get("Date") + "\r\n" +
                 "Content-Language: " + headers.get("Content-Language") + "\r\n" +
                 "\r\n";
-        HeadResponse headResponse = new HeadResponse(version, status, headers);
+        HeadResponse headResponse = new HeadResponse(version, status);
 
         String stringifiedResponse = headResponse.stringifyResponse();
 
         assertEquals(expectedResponse, stringifiedResponse);
+    }
+
+    @Test
+    @DisplayName("A Header should be generated with at minimum the date")
+    void generateHeaders_DefaultDate() {
+        Map<String,String> defaultHeader = new HashMap<>() {{
+            put("Date", new Date().toString());
+        }};
+        Response response = new HeadResponse(version, status);
+
+        Map<String, String> generatedHeaders = response.generateHeaders();
+
+        assertTrue(generatedHeaders.containsKey("Date"));
     }
 
 }

--- a/app/src/test/java/ikarabulut/http/response/HeadResponseTest.java
+++ b/app/src/test/java/ikarabulut/http/response/HeadResponseTest.java
@@ -11,8 +11,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class HeadResponseTest {
     private String version = "HTTP/1.1";
-    private StatusCode statusCode = StatusCode.OK;
-    private String statusNumber = statusCode.getStatusNumber();
+    private StatusCode status = StatusCode.OK;
     private Map<String, String> headers = new HashMap<>() {
         {
             put("Date", new Date().toString());
@@ -23,11 +22,14 @@ class HeadResponseTest {
     @Test
     @DisplayName("With a valid path, stringifyHeadResponse should return a string with a status line and headers")
     void stringifyResponse_ForHead() {
+        String statusNumber = status.getStatusNumber();
+        String statusCode = status.getStatusCode();
+
         String expectedResponse = version + " " + statusNumber + " " + statusCode + "\r\n" +
                 "Date: " + headers.get("Date") + "\r\n" +
                 "Content-Language: " + headers.get("Content-Language") + "\r\n" +
                 "\r\n";
-        HeadResponse headResponse = new HeadResponse(version, statusCode, statusNumber, headers);
+        HeadResponse headResponse = new HeadResponse(version, status, headers);
 
         String stringifiedResponse = headResponse.stringifyResponse();
 

--- a/app/src/test/java/ikarabulut/http/response/MethodNotAllowedResponseTest.java
+++ b/app/src/test/java/ikarabulut/http/response/MethodNotAllowedResponseTest.java
@@ -10,8 +10,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class MethodNotAllowedResponseTest {
     private String version = "HTTP/1.1";
-    private String statusCode = StatusCode.NOT_ALLOWED.getStatusCode();
-    private String statusNumber = StatusCode.NOT_ALLOWED.getStatusNumber();
+    private StatusCode status = StatusCode.NOT_ALLOWED;
     private Map<String, String> headers = new HashMap<>() {
         {
             put("Allow", "HEAD, OPTIONS");
@@ -21,9 +20,12 @@ class MethodNotAllowedResponseTest {
     @Test
     @DisplayName("A MethodNotAllowedResponse should return a 405 error with the allow header")
     void stringifyResponse() {
+        String statusCode = status.getStatusCode();
+        String statusNumber = status.getStatusNumber();
         String expectedResponse = version + " " + statusNumber + " " + statusCode + "\r\n" +
                 "Allow: " + headers.get("Allow") + "\r\n" + "\r\n";
-        Response response = new MethodNotAllowedResponse(version, statusCode, statusNumber, headers);
+        Response response = new MethodNotAllowedResponse(version, status, headers);
+
         String stringifiedResponse = response.stringifyResponse();
 
         assertEquals(expectedResponse, stringifiedResponse);

--- a/app/src/test/java/ikarabulut/http/response/MethodNotAllowedResponseTest.java
+++ b/app/src/test/java/ikarabulut/http/response/MethodNotAllowedResponseTest.java
@@ -3,6 +3,8 @@ package ikarabulut.http.response;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -24,11 +26,24 @@ class MethodNotAllowedResponseTest {
         String statusNumber = status.getStatusNumber();
         String expectedResponse = version + " " + statusNumber + " " + statusCode + "\r\n" +
                 "Allow: " + headers.get("Allow") + "\r\n" + "\r\n";
-        Response response = new MethodNotAllowedResponse(version, status, headers);
+        Response response = new MethodNotAllowedResponse(version, status);
 
         String stringifiedResponse = response.stringifyResponse();
 
         assertEquals(expectedResponse, stringifiedResponse);
+    }
+
+    @Test
+    @DisplayName("A Header should be generated with at minimum the Allow name")
+    void generateHeaders_DefaultAllow() {
+        Map<String,String> defaultHeader = new HashMap<>() {{
+            put("Allow", "HEAD, GET");
+        }};
+        Response response = new MethodNotAllowedResponse(version, status);
+
+        Map<String, String> generatedHeaders = response.generateHeaders();
+
+        assertTrue(generatedHeaders.containsKey("Allow"));
     }
 
 }


### PR DESCRIPTION
Refactoring PR

**Main Changes**
- The `Response` objects had TellDontAsk implemented in their constructors. Instead of taking in the individual statusCode and statusNumber objects in their constructors. They now take in the entire `StatusCode` object and its `getStatusCode / getStatusNumber` are called to get the required data.
- Instance variables in the `Response` objects were changed from `protected` to `private` idk why they were `protected` in the first place
- The `generateHeader` responsibility was moved from the `RequestHandler` objects to the `Response` objects with the tests moved as well. 

My intention with moving that responsibility (generateHeader) was to create a more clear path to create a `Header` object, one that can dynamically generate headers. And it would be better suited to have that live closer to the Object that requires that feature which is `Response` not `Handler`