### PR TITLE
Simple post story / adds parse headers feature

### DIFF
--- a/app/src/main/java/ikarabulut/http/parser/RequestParser.java
+++ b/app/src/main/java/ikarabulut/http/parser/RequestParser.java
@@ -8,7 +8,7 @@ import java.util.*;
 public class RequestParser {
     private ClientReader clientReader;
     private String rawRequest;
-    private List<String> body = new ArrayList<>();
+    private String body;
 
     public RequestParser(ClientReader clientReader) {
         this.clientReader = clientReader;
@@ -55,15 +55,17 @@ public class RequestParser {
         List splitRequest = Arrays.asList(rawRequest.split("\r?\n"));
         int indexOfEmptyLine = splitRequest.indexOf("");
 
-        for (int i = indexOfEmptyLine + 1; i < splitRequest.size(); i++) {
-            System.out.println(splitRequest.get(i).getClass());
-            body.add((String) splitRequest.get(i));
+        if (indexOfEmptyLine != -1) {
+            StringBuilder stringBuilder = new StringBuilder();
+            for (int i = indexOfEmptyLine + 1; i < splitRequest.size(); i++) {
+                stringBuilder.append(splitRequest.get(i));
+            }
+            body = stringBuilder.toString();
         }
     }
 
-    public List<String> getBody() {
-        return this.body;
+    public String getBody() {
+        return body;
     }
-
-
+    
 }

--- a/app/src/main/java/ikarabulut/http/parser/RequestParser.java
+++ b/app/src/main/java/ikarabulut/http/parser/RequestParser.java
@@ -3,12 +3,12 @@ package ikarabulut.http.parser;
 import ikarabulut.http.io.ClientReader;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 public class RequestParser {
     private ClientReader clientReader;
     private String rawRequest;
+    private List<String> body = new ArrayList<>();
 
     public RequestParser(ClientReader clientReader) {
         this.clientReader = clientReader;
@@ -50,5 +50,20 @@ public class RequestParser {
         }
         return headers;
     }
+
+    public void parseBody() {
+        List splitRequest = Arrays.asList(rawRequest.split("\r?\n"));
+        int indexOfEmptyLine = splitRequest.indexOf("");
+
+        for (int i = indexOfEmptyLine + 1; i < splitRequest.size(); i++) {
+            System.out.println(splitRequest.get(i).getClass());
+            body.add((String) splitRequest.get(i));
+        }
+    }
+
+    public List<String> getBody() {
+        return this.body;
+    }
+
 
 }

--- a/app/src/test/java/ikarabulut/http/parser/RequestParserTest.java
+++ b/app/src/test/java/ikarabulut/http/parser/RequestParserTest.java
@@ -5,7 +5,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -15,6 +18,9 @@ class RequestParserTest {
             "Content-Type" + ":" + " text/plain\r\n" +
             "User-Agent" + ":" + " PostmanRuntime/7.29.0\r\n\r\n" +
             "Hello World\r\n";
+    private String inputWithoutBody = "HEAD /test HTTP/1.1\r\n" +
+            "Content-Type" + ":" + " text/plain\r\n" +
+            "User-Agent" + ":" + " PostmanRuntime/7.29.0\r\n\r\n";
 
     @Test
     @DisplayName("When parsing the initial line, a HashMap containing 'httpMethod', 'httpPath', 'httpVersion' keys and corresponding keys should be generated")
@@ -48,6 +54,21 @@ class RequestParserTest {
 
         assertEquals(expectedHeaders, returnedHeaders);
     }
+
+    @Test
+    @DisplayName("A Request with a body should have that body parsed into a body object within RequestParser ")
+    void parseBody() throws IOException {
+        InputStream in = new ByteArrayInputStream(input.getBytes());
+        ClientReader clientReader = new ClientReader(in);
+        RequestParser requestParser = new RequestParser(clientReader);
+
+        requestParser.parseBody();
+
+        List<String> parsedBody = requestParser.getBody();
+        List<String> expectedParsedBody = Arrays.asList("Hello World");
+        assertEquals(expectedParsedBody, parsedBody);
+    }
+
 
 
 }

--- a/app/src/test/java/ikarabulut/http/parser/RequestParserTest.java
+++ b/app/src/test/java/ikarabulut/http/parser/RequestParserTest.java
@@ -64,11 +64,23 @@ class RequestParserTest {
 
         requestParser.parseBody();
 
-        List<String> parsedBody = requestParser.getBody();
-        List<String> expectedParsedBody = Arrays.asList("Hello World");
+        String parsedBody = requestParser.getBody();
+        String expectedParsedBody = "Hello World";
         assertEquals(expectedParsedBody, parsedBody);
     }
 
+    @Test
+    @DisplayName("A Request without a body should return a null body object")
+    void parseBody_WhenNoBody() throws IOException {
+        InputStream in = new ByteArrayInputStream(inputWithoutBody.getBytes());
+        ClientReader clientReader = new ClientReader(in);
+        RequestParser requestParser = new RequestParser(clientReader);
+
+        requestParser.parseBody();
+
+        String parsedBody = requestParser.getBody();
+        assertNull(parsedBody);
+    }
 
 
 }


### PR DESCRIPTION
This PR covers my implementation to parse the body from a request. This work was done in `RequestParser`. With this added functionality, a client now has the ability to grab a body object to be later used. In this case, to be used to echo back in the response.

Added methods
`parseBody()`: This method takes the raw request `String` and splits it into a splitRequest `List` from there it will figure out where the empty line is that separates the headers from the body. If there is an empty line it will add everything after that empty line into a StringBuilder to eventually convert into a `String`

`getBody()`: This returns the `String body` object. This can be `null` during the `parseBody` process if the index of the empty line is `-1` it will not generate anything leaving the body null.

Tests were added to `Request Parser` to check a request with and without a body.

**Planned Next Steps**
- A `Route` object will take in a `RequestParser` object argument instead of an `initialLine List` this opens up the ability for clients to have a single object with all of the request information to pass around. This will be a refactoring of the `Route` class and all clients using `Route` and the `initialLine`.
- A `PostRequestHandler` and then `PostResponse` object will be created