### PR TITLE
Simple post story / passes simple_post acceptance test

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,6 @@ This project is built in [Java (OpenJDK 18)](https://www.oracle.com/java/technol
   - After install you can run `java --version` to confirm proper installation
 - **Gradle**
   - Follow these [Gradle doc instructions](https://gradle.org/install/)
-  
-- **[direnv](https://direnv.net/)**
-  - Used for local environment variables
-  - To install using homebrew run `brew install direnv` in your terminal
-  - Follow these instructions to hook direnv to your shell https://direnv.net/docs/hook.html
-    - For ZSH add the following line to your .zshrc file
-      - `eval "$(direnv hook zsh)"`
-
 
 ## Functional Requirements
 
@@ -39,26 +31,25 @@ This project is built in [Java (OpenJDK 18)](https://www.oracle.com/java/technol
 ---
 🟢 Simple HEAD request
 
-🔴 Simple GET request
+🟢 Simple GET request
 
 🔴 Simple OPTIONS request
 
-🔴 Simple POST request
+🟢 Simple POST request
 
 🔴 Redirect feature
 
-🔴 Method not found feature
+🟢 Method not found feature
 
 🔴 Page not found feature
 
 ## Installation
 
 ---
-1. Clone the repo to your machine, and `cd` into the directory, run the `direnv allow` to load the local env variables using direnv
+1. Clone the repo to your machine, and `cd` into the directory
 ```
 git clone https://github.com/ikarabulut/HttpServer.git
 cd HttpServer
-direnv allow
 ```
 2. Build the App
 ```

--- a/app/src/main/java/ikarabulut/http/handlers/PostRequestHandler.java
+++ b/app/src/main/java/ikarabulut/http/handlers/PostRequestHandler.java
@@ -8,17 +8,17 @@ import ikarabulut.http.response.StatusCode;
 import java.util.Map;
 
 public class PostRequestHandler implements RequestHandler {
-    private RequestParser parsedRequest;
+    private RequestParser rawRequest;
 
-    public PostRequestHandler(RequestParser parsedRequest) {
-        this.parsedRequest = parsedRequest;
+    public PostRequestHandler(RequestParser rawRequest) {
+        this.rawRequest = rawRequest;
     }
 
     public Response processResponse() {
-        Map<String, String> initialLine = parsedRequest.parseInitialLine();
+        Map<String, String> initialLine = rawRequest.parseInitialLine();
         String version = initialLine.get("httpVersion");
         StatusCode status = StatusCode.OK;
-        String body = parsedRequest.parseBody();
+        String body = rawRequest.parseBody();
 
         return new PostResponse(version, status, body);
     }

--- a/app/src/main/java/ikarabulut/http/handlers/PostRequestHandler.java
+++ b/app/src/main/java/ikarabulut/http/handlers/PostRequestHandler.java
@@ -1,6 +1,7 @@
 package ikarabulut.http.handlers;
 
 import ikarabulut.http.parser.RequestParser;
+import ikarabulut.http.response.PostResponse;
 import ikarabulut.http.response.Response;
 import ikarabulut.http.response.StatusCode;
 
@@ -19,7 +20,7 @@ public class PostRequestHandler implements RequestHandler {
         StatusCode status = StatusCode.OK;
         String body = parsedRequest.parseBody();
 
-        return null;
+        return new PostResponse(version, status, body);
     }
 
 

--- a/app/src/main/java/ikarabulut/http/handlers/PostRequestHandler.java
+++ b/app/src/main/java/ikarabulut/http/handlers/PostRequestHandler.java
@@ -1,0 +1,26 @@
+package ikarabulut.http.handlers;
+
+import ikarabulut.http.parser.RequestParser;
+import ikarabulut.http.response.Response;
+import ikarabulut.http.response.StatusCode;
+
+import java.util.Map;
+
+public class PostRequestHandler implements RequestHandler {
+    private RequestParser parsedRequest;
+
+    public PostRequestHandler(RequestParser parsedRequest) {
+        this.parsedRequest = parsedRequest;
+    }
+
+    public Response processResponse() {
+        Map<String, String> initialLine = parsedRequest.parseInitialLine();
+        String version = initialLine.get("httpVersion");
+        StatusCode status = StatusCode.OK;
+        String body = parsedRequest.parseBody();
+
+        return null;
+    }
+
+
+}

--- a/app/src/main/java/ikarabulut/http/parser/RequestParser.java
+++ b/app/src/main/java/ikarabulut/http/parser/RequestParser.java
@@ -8,7 +8,7 @@ import java.util.*;
 public class RequestParser {
     private ClientReader clientReader;
     private String rawRequest;
-    private List<String> body = new ArrayList<>();
+    private String body;
 
     public RequestParser(ClientReader clientReader) {
         this.clientReader = clientReader;
@@ -55,15 +55,17 @@ public class RequestParser {
         List splitRequest = Arrays.asList(rawRequest.split("\r?\n"));
         int indexOfEmptyLine = splitRequest.indexOf("");
 
-        for (int i = indexOfEmptyLine + 1; i < splitRequest.size(); i++) {
-            System.out.println(splitRequest.get(i).getClass());
-            body.add((String) splitRequest.get(i));
+        if (indexOfEmptyLine != -1) {
+            StringBuilder stringBuilder = new StringBuilder();
+            for (int i = indexOfEmptyLine + 1; i < splitRequest.size(); i++) {
+                stringBuilder.append(splitRequest.get(i));
+            }
+            body = stringBuilder.toString();
         }
     }
 
-    public List<String> getBody() {
-        return this.body;
+    public String getBody() {
+        return body;
     }
-
-
+    
 }

--- a/app/src/main/java/ikarabulut/http/parser/RequestParser.java
+++ b/app/src/main/java/ikarabulut/http/parser/RequestParser.java
@@ -3,12 +3,12 @@ package ikarabulut.http.parser;
 import ikarabulut.http.io.ClientReader;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 public class RequestParser {
     private ClientReader clientReader;
     private String rawRequest;
+    private List<String> body = new ArrayList<>();
 
     public RequestParser(ClientReader clientReader) {
         this.clientReader = clientReader;
@@ -50,5 +50,20 @@ public class RequestParser {
         }
         return headers;
     }
+
+    public void parseBody() {
+        List splitRequest = Arrays.asList(rawRequest.split("\r?\n"));
+        int indexOfEmptyLine = splitRequest.indexOf("");
+
+        for (int i = indexOfEmptyLine + 1; i < splitRequest.size(); i++) {
+            System.out.println(splitRequest.get(i).getClass());
+            body.add((String) splitRequest.get(i));
+        }
+    }
+
+    public List<String> getBody() {
+        return this.body;
+    }
+
 
 }

--- a/app/src/main/java/ikarabulut/http/parser/RequestParser.java
+++ b/app/src/main/java/ikarabulut/http/parser/RequestParser.java
@@ -61,7 +61,7 @@ public class RequestParser {
             }
             return stringBuilder.toString();
         }
-        return null;
+        return "";
     }
     
 }

--- a/app/src/main/java/ikarabulut/http/parser/RequestParser.java
+++ b/app/src/main/java/ikarabulut/http/parser/RequestParser.java
@@ -8,7 +8,6 @@ import java.util.*;
 public class RequestParser {
     private ClientReader clientReader;
     private String rawRequest;
-    private String body;
 
     public RequestParser(ClientReader clientReader) {
         this.clientReader = clientReader;
@@ -51,7 +50,7 @@ public class RequestParser {
         return headers;
     }
 
-    public void parseBody() {
+    public String parseBody() {
         List splitRequest = Arrays.asList(rawRequest.split("\r?\n"));
         int indexOfEmptyLine = splitRequest.indexOf("");
 
@@ -60,12 +59,9 @@ public class RequestParser {
             for (int i = indexOfEmptyLine + 1; i < splitRequest.size(); i++) {
                 stringBuilder.append(splitRequest.get(i));
             }
-            body = stringBuilder.toString();
+            return stringBuilder.toString();
         }
-    }
-
-    public String getBody() {
-        return body;
+        return null;
     }
     
 }

--- a/app/src/main/java/ikarabulut/http/response/PostResponse.java
+++ b/app/src/main/java/ikarabulut/http/response/PostResponse.java
@@ -1,0 +1,53 @@
+package ikarabulut.http.response;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+public class PostResponse implements Response {
+    private String version;
+    private StatusCode status;
+    private Map<String, String> headers;
+    private String body;
+
+    public PostResponse(String version, StatusCode status, String body) {
+        this.version = version;
+        this.status = status;
+        this.body = body;
+    }
+
+    public Map<String, String> generateHeaders() {
+        headers = new HashMap<>() {{
+            put("Date", new Date().toString());
+            put("Content-Language", "en-US");
+        }};
+
+        return headers;
+    }
+
+    public String stringifyResponse() {
+        String statusCode = status.getStatusCode();
+        String statusNumber = status.getStatusNumber();
+
+        String initialLine = version + SPACE + statusNumber + SPACE + statusCode + CRLF;
+        String headers = stringifyHeaders();
+
+        return initialLine + headers + body;
+    }
+
+    public boolean hasBody() {
+        return !body.equals(EMPTYBODY);
+    }
+
+    private String stringifyHeaders() {
+        generateHeaders();
+
+        StringBuilder headersAsAString = new StringBuilder();
+        for (Map.Entry<String, String> set : headers.entrySet()) {
+            headersAsAString.append(set.getKey()).append(": ").append(set.getValue()).append(CRLF);
+        }
+        headersAsAString.append(CRLF);
+        return headersAsAString.toString();
+    }
+
+}

--- a/app/src/main/java/ikarabulut/http/server/Router.java
+++ b/app/src/main/java/ikarabulut/http/server/Router.java
@@ -61,13 +61,13 @@ public class Router {
     }
 
     public Response runPostRequest() {
-        PostRequestHandler requestHandler = new PostRequestHandler(parsedRequest);
+        PostRequestHandler requestHandler = new PostRequestHandler(rawRequest);
         return requestHandler.processResponse();
     }
 
     public Response methodNotAllowed(List<String> acceptedMethods) {
-        MethodNotAllowedHandler handler = new MethodNotAllowedHandler(acceptedMethods, initialLine);
-        return handler.processResponse();
+        MethodNotAllowedHandler requestHandler = new MethodNotAllowedHandler(acceptedMethods, initialLine);
+        return requestHandler.processResponse();
     }
 
     private boolean pathIncludesMethod() {

--- a/app/src/main/java/ikarabulut/http/server/Router.java
+++ b/app/src/main/java/ikarabulut/http/server/Router.java
@@ -24,6 +24,7 @@ public class Router {
             put("/head_request", Arrays.asList("HEAD", "OPTIONS"));
             put("/simple_get", Arrays.asList("GET", "HEAD"));
             put("/simple_get_with_body", Arrays.asList("GET", "HEAD"));
+            put("/echo_body", Arrays.asList("POST", "HEAD"));
         }};
     }
 
@@ -38,6 +39,8 @@ public class Router {
                 return runHeadRequest();
             case "GET":
                 return runGetRequest();
+            case "POST":
+                return runPostRequest();
         }
         return null;
     }
@@ -54,6 +57,11 @@ public class Router {
         Response response = requestRunner.processResponse();
 
         return response;
+    }
+
+    public Response runPostRequest() {
+
+        return null;
     }
 
     public Response methodNotAllowed(List<String> acceptedMethods) {

--- a/app/src/main/java/ikarabulut/http/server/Router.java
+++ b/app/src/main/java/ikarabulut/http/server/Router.java
@@ -3,6 +3,7 @@ package ikarabulut.http.server;
 import ikarabulut.http.handlers.GetRequestHandler;
 import ikarabulut.http.handlers.HeadRequestHandler;
 import ikarabulut.http.handlers.MethodNotAllowedHandler;
+import ikarabulut.http.handlers.PostRequestHandler;
 import ikarabulut.http.parser.RequestParser;
 import ikarabulut.http.response.Response;
 
@@ -60,8 +61,8 @@ public class Router {
     }
 
     public Response runPostRequest() {
-
-        return null;
+        PostRequestHandler requestHandler = new PostRequestHandler(parsedRequest);
+        return requestHandler.processResponse();
     }
 
     public Response methodNotAllowed(List<String> acceptedMethods) {

--- a/app/src/test/java/ikarabulut/http/handlers/PostRequestHandlerTest.java
+++ b/app/src/test/java/ikarabulut/http/handlers/PostRequestHandlerTest.java
@@ -20,7 +20,7 @@ class PostRequestHandlerTest {
     }
 
     @Test
-    @DisplayName("PostRequestHandler should echo back the body of the request by calling parseBody from the composed RequestParser")
+    @DisplayName("PostRequestHandler should call parseBody from the RequestParser within processResponse()")
     void processResponse_EchosRequestBody() {
         RequestParser parsedRequest = mock(RequestParser.class);
         RequestHandler requestHandler = new PostRequestHandler(parsedRequest);

--- a/app/src/test/java/ikarabulut/http/handlers/PostRequestHandlerTest.java
+++ b/app/src/test/java/ikarabulut/http/handlers/PostRequestHandlerTest.java
@@ -1,0 +1,33 @@
+package ikarabulut.http.handlers;
+
+import ikarabulut.http.parser.RequestParser;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class PostRequestHandlerTest {
+    @Test
+    @DisplayName("PostRequestHandler should process the response using the initial line from the composed RequestParser object")
+    void processResponse_UsesRequestParser() {
+        RequestParser parsedRequest = mock(RequestParser.class);
+        RequestHandler requestHandler = new PostRequestHandler(parsedRequest);
+
+        requestHandler.processResponse();
+
+        verify(parsedRequest).parseInitialLine();
+    }
+
+    @Test
+    @DisplayName("PostRequestHandler should echo back the body of the request by calling parseBody from the composed RequestParser")
+    void processResponse_EchosRequestBody() {
+        RequestParser parsedRequest = mock(RequestParser.class);
+        RequestHandler requestHandler = new PostRequestHandler(parsedRequest);
+
+        requestHandler.processResponse();
+
+        verify(parsedRequest).parseInitialLine();
+    }
+
+}

--- a/app/src/test/java/ikarabulut/http/handlers/PostRequestHandlerTest.java
+++ b/app/src/test/java/ikarabulut/http/handlers/PostRequestHandlerTest.java
@@ -27,7 +27,7 @@ class PostRequestHandlerTest {
 
         requestHandler.processResponse();
 
-        verify(parsedRequest).parseInitialLine();
+        verify(parsedRequest).parseBody();
     }
 
 }

--- a/app/src/test/java/ikarabulut/http/parser/RequestParserTest.java
+++ b/app/src/test/java/ikarabulut/http/parser/RequestParserTest.java
@@ -69,7 +69,7 @@ class RequestParserTest {
     }
 
     @Test
-    @DisplayName("A Request without a body should return a null body object")
+    @DisplayName("A Request without a body should return null")
     void parseBody_WhenNoBody() throws IOException {
         InputStream in = new ByteArrayInputStream(inputWithoutBody.getBytes());
         ClientReader clientReader = new ClientReader(in);

--- a/app/src/test/java/ikarabulut/http/parser/RequestParserTest.java
+++ b/app/src/test/java/ikarabulut/http/parser/RequestParserTest.java
@@ -5,7 +5,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -15,6 +18,9 @@ class RequestParserTest {
             "Content-Type" + ":" + " text/plain\r\n" +
             "User-Agent" + ":" + " PostmanRuntime/7.29.0\r\n\r\n" +
             "Hello World\r\n";
+    private String inputWithoutBody = "HEAD /test HTTP/1.1\r\n" +
+            "Content-Type" + ":" + " text/plain\r\n" +
+            "User-Agent" + ":" + " PostmanRuntime/7.29.0\r\n\r\n";
 
     @Test
     @DisplayName("When parsing the initial line, a HashMap containing 'httpMethod', 'httpPath', 'httpVersion' keys and corresponding keys should be generated")
@@ -48,6 +54,21 @@ class RequestParserTest {
 
         assertEquals(expectedHeaders, returnedHeaders);
     }
+
+    @Test
+    @DisplayName("A Request with a body should have that body parsed into a body object within RequestParser ")
+    void parseBody() throws IOException {
+        InputStream in = new ByteArrayInputStream(input.getBytes());
+        ClientReader clientReader = new ClientReader(in);
+        RequestParser requestParser = new RequestParser(clientReader);
+
+        requestParser.parseBody();
+
+        List<String> parsedBody = requestParser.getBody();
+        List<String> expectedParsedBody = Arrays.asList("Hello World");
+        assertEquals(expectedParsedBody, parsedBody);
+    }
+
 
 
 }

--- a/app/src/test/java/ikarabulut/http/parser/RequestParserTest.java
+++ b/app/src/test/java/ikarabulut/http/parser/RequestParserTest.java
@@ -62,9 +62,8 @@ class RequestParserTest {
         ClientReader clientReader = new ClientReader(in);
         RequestParser requestParser = new RequestParser(clientReader);
 
-        requestParser.parseBody();
-
-        String parsedBody = requestParser.getBody();
+        String parsedBody = requestParser.parseBody();
+        
         String expectedParsedBody = "Hello World";
         assertEquals(expectedParsedBody, parsedBody);
     }
@@ -76,9 +75,8 @@ class RequestParserTest {
         ClientReader clientReader = new ClientReader(in);
         RequestParser requestParser = new RequestParser(clientReader);
 
-        requestParser.parseBody();
+        String parsedBody = requestParser.parseBody();
 
-        String parsedBody = requestParser.getBody();
         assertNull(parsedBody);
     }
 

--- a/app/src/test/java/ikarabulut/http/parser/RequestParserTest.java
+++ b/app/src/test/java/ikarabulut/http/parser/RequestParserTest.java
@@ -69,7 +69,7 @@ class RequestParserTest {
     }
 
     @Test
-    @DisplayName("A Request without a body should return null")
+    @DisplayName("A Request without a body should return an empty string")
     void parseBody_WhenNoBody() throws IOException {
         InputStream in = new ByteArrayInputStream(inputWithoutBody.getBytes());
         ClientReader clientReader = new ClientReader(in);
@@ -77,7 +77,7 @@ class RequestParserTest {
 
         String parsedBody = requestParser.parseBody();
 
-        assertNull(parsedBody);
+        assertEquals("", parsedBody);
     }
 
 

--- a/app/src/test/java/ikarabulut/http/parser/RequestParserTest.java
+++ b/app/src/test/java/ikarabulut/http/parser/RequestParserTest.java
@@ -64,11 +64,23 @@ class RequestParserTest {
 
         requestParser.parseBody();
 
-        List<String> parsedBody = requestParser.getBody();
-        List<String> expectedParsedBody = Arrays.asList("Hello World");
+        String parsedBody = requestParser.getBody();
+        String expectedParsedBody = "Hello World";
         assertEquals(expectedParsedBody, parsedBody);
     }
 
+    @Test
+    @DisplayName("A Request without a body should return a null body object")
+    void parseBody_WhenNoBody() throws IOException {
+        InputStream in = new ByteArrayInputStream(inputWithoutBody.getBytes());
+        ClientReader clientReader = new ClientReader(in);
+        RequestParser requestParser = new RequestParser(clientReader);
+
+        requestParser.parseBody();
+
+        String parsedBody = requestParser.getBody();
+        assertNull(parsedBody);
+    }
 
 
 }

--- a/app/src/test/java/ikarabulut/http/response/PostResponseTest.java
+++ b/app/src/test/java/ikarabulut/http/response/PostResponseTest.java
@@ -1,0 +1,51 @@
+package ikarabulut.http.response;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PostResponseTest {
+    private String version = "HTTP/1.1";
+    private StatusCode status = StatusCode.OK;
+    private String body = "hello world";
+
+    @Test
+    @DisplayName("PostResponse should be able to generate headers with at minimum the date")
+    void generateHeaders_DefaultValues() {
+        Map<String,String> defaultHeader = new HashMap<>() {{
+            put("Date", new Date().toString());
+        }};
+        Response response = new PostResponse(version, status, body);
+
+        Map<String, String> generatedHeaders = response.generateHeaders();
+
+        assertTrue(generatedHeaders.containsKey("Date"));
+    }
+
+    @Test
+    @DisplayName("A PostResponse with a status code of OK should generate a string response with 200 and OK")
+    void stringifyResponse_HasStatusCodeValues() {
+        Response response = new PostResponse(version, status, body);
+
+        String receivedResponse = response.stringifyResponse();
+
+        assertTrue(receivedResponse.contains("OK"));
+        assertTrue(receivedResponse.contains("200"));
+    }
+
+    @Test
+    @DisplayName("A PostResponse with using HTTP 1.1 protocol should generate a string response with HTTP/1.1")
+    void stringifyResponse_HasCorrectVersion() {
+        Response response = new PostResponse(version, status, body);
+
+        String receivedResponse = response.stringifyResponse();
+
+        assertTrue(receivedResponse.contains("HTTP/1.1"));
+    }
+
+}

--- a/app/src/test/java/ikarabulut/http/server/RouterTest.java
+++ b/app/src/test/java/ikarabulut/http/server/RouterTest.java
@@ -63,4 +63,20 @@ class RouterTest {
         Mockito.verify(spyRouter).methodNotAllowed(Arrays.asList("HEAD", "OPTIONS"));
     }
 
+    @Test
+    @DisplayName("When a POST request is made with a valid path, then routeRequest should call runPostMethod()")
+    void routeRequest_PostRequest() {
+        RequestParser parsedRequest = mock(RequestParser.class);
+        initialLine.put("httpMethod", "POST");
+        initialLine.put("httpPath", "/echo_body");
+        initialLine.put("httpVersion", "HTTP/1.1");
+        when(parsedRequest.parseInitialLine()).thenReturn(initialLine);
+        Router router = new Router(parsedRequest);
+        Router spyRouter = Mockito.spy(router);
+
+        spyRouter.routeRequest();
+
+        Mockito.verify(spyRouter).runPostRequest();
+    }
+
 }

--- a/http_server_spec/features/01_getting_started/simple_post.feature
+++ b/http_server_spec/features/01_getting_started/simple_post.feature
@@ -1,6 +1,5 @@
 @simple-post @01-getting-started
 Feature: Simple POST
-  @wip
   Scenario: Posting echos the body
     Given I make a POST with a body to "/echo_body"
     Then my response should have status code 200


### PR DESCRIPTION
This PR covers the additional features added to get the `simple_post` acceptance test passing.

Features added:

- `PostRequestHandler` this `RequestHandler` object currently implements `processResponse()` and hardcodes the body of the response to be the body of the request that came in.
	- This uses the new `parseBody()` method within `RequestParser` which returns a `String` object representing the body of the request
- `PostResponse` this `Response` object implements the abstract `Response` methods to generate the headers, and generate a string object representing the response. 
- These added features are similar in implementation to the other `RequestHandler` and `Response` objects within the program.

Potential improvements to consider:

- Allowing the Headers to be dynamically generated. I set up `generateHeaders()` to be a bit more flexible in potentially adding a new object whos purpose is to generate headers. so instead of `generateHeaders` returning a `Map` it can return a `Header` object that can have its data accessed similar to `RequestParser` 
- Implementing a feature to dynamically grab the body response for a `Post` request. Instead of hardcoding the body within the `processResponse` method in `PostRequestHandler` . I'm anticipating that this will be addressed when later features are implemented.
