### PR TITLE
Page not found story / adds functionality to pass page_not_found acceptance test

### DIFF
--- a/app/src/main/java/ikarabulut/http/handlers/PageNotFoundHandler.java
+++ b/app/src/main/java/ikarabulut/http/handlers/PageNotFoundHandler.java
@@ -1,0 +1,19 @@
+package ikarabulut.http.handlers;
+
+import ikarabulut.http.parser.RequestParser;
+import ikarabulut.http.response.Response;
+import ikarabulut.http.response.StatusCode;
+
+public class PageNotFoundHandler implements RequestHandler {
+    private StatusCode code;
+    private RequestParser rawRequest;
+
+    public PageNotFoundHandler(RequestParser rawRequest) {
+        this.rawRequest = rawRequest;
+        this.code = StatusCode.NOT_FOUND;
+    }
+    public Response processResponse() {
+        return null; //TEMPORARY
+    }
+
+}

--- a/app/src/main/java/ikarabulut/http/handlers/PageNotFoundHandler.java
+++ b/app/src/main/java/ikarabulut/http/handlers/PageNotFoundHandler.java
@@ -8,17 +8,16 @@ import ikarabulut.http.response.StatusCode;
 import java.util.Map;
 
 public class PageNotFoundHandler implements RequestHandler {
-    private StatusCode code;
     private RequestParser rawRequest;
 
     public PageNotFoundHandler(RequestParser rawRequest) {
         this.rawRequest = rawRequest;
-        this.code = StatusCode.NOT_FOUND;
     }
     public Response processResponse() {
         Map<String, String> initialLine = rawRequest.parseInitialLine();
+        StatusCode status = StatusCode.NOT_FOUND;
         String version = initialLine.get("httpVersion");
-        return new PageNotFoundResponse(version, this.code);
+        return new PageNotFoundResponse(version, status);
     }
 
 }

--- a/app/src/main/java/ikarabulut/http/handlers/PageNotFoundHandler.java
+++ b/app/src/main/java/ikarabulut/http/handlers/PageNotFoundHandler.java
@@ -1,8 +1,11 @@
 package ikarabulut.http.handlers;
 
 import ikarabulut.http.parser.RequestParser;
+import ikarabulut.http.response.PageNotFoundResponse;
 import ikarabulut.http.response.Response;
 import ikarabulut.http.response.StatusCode;
+
+import java.util.Map;
 
 public class PageNotFoundHandler implements RequestHandler {
     private StatusCode code;
@@ -13,7 +16,9 @@ public class PageNotFoundHandler implements RequestHandler {
         this.code = StatusCode.NOT_FOUND;
     }
     public Response processResponse() {
-        return null; //TEMPORARY
+        Map<String, String> initialLine = rawRequest.parseInitialLine();
+        String version = initialLine.get("httpVersion");
+        return new PageNotFoundResponse(version, this.code);
     }
 
 }

--- a/app/src/main/java/ikarabulut/http/response/PageNotFoundResponse.java
+++ b/app/src/main/java/ikarabulut/http/response/PageNotFoundResponse.java
@@ -44,4 +44,5 @@ public class PageNotFoundResponse implements Response {
         headersAsAString.append(CRLF);
         return headersAsAString.toString();
     }
+
 }

--- a/app/src/main/java/ikarabulut/http/response/PageNotFoundResponse.java
+++ b/app/src/main/java/ikarabulut/http/response/PageNotFoundResponse.java
@@ -1,0 +1,2 @@
+package ikarabulut.http.response;public class PageNotFoundResponse {
+}

--- a/app/src/main/java/ikarabulut/http/response/PageNotFoundResponse.java
+++ b/app/src/main/java/ikarabulut/http/response/PageNotFoundResponse.java
@@ -1,2 +1,47 @@
-package ikarabulut.http.response;public class PageNotFoundResponse {
+package ikarabulut.http.response;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+public class PageNotFoundResponse implements Response {
+    private String version;
+    private StatusCode status;
+    private Map<String, String> headers;
+
+    public PageNotFoundResponse(String version, StatusCode status) {
+        this.version = version;
+        this.status = status;
+    }
+
+    public String stringifyResponse() {
+        String statusCode = status.getStatusCode();
+        String statusNumber = status.getStatusNumber();
+
+        String initialLine = version + SPACE + statusNumber + SPACE + statusCode + CRLF;
+        String headers = stringifyHeaders();
+
+        return initialLine + headers;
+    }
+
+    public Map<String, String> generateHeaders() {
+        headers = new HashMap<>() {{
+            put("Date", new Date().toString());
+            put("Content-Language", "en-US");
+        }};
+        return headers;
+    }
+
+    public boolean hasBody() { return false; }
+
+    private String stringifyHeaders() {
+        generateHeaders();
+
+        StringBuilder headersAsAString = new StringBuilder();
+        for (Map.Entry<String, String> set : headers.entrySet()) {
+            headersAsAString.append(set.getKey()).append(": ").append(set.getValue()).append(CRLF);
+        }
+        headersAsAString.append(CRLF);
+        return headersAsAString.toString();
+    }
 }

--- a/app/src/main/java/ikarabulut/http/response/StatusCode.java
+++ b/app/src/main/java/ikarabulut/http/response/StatusCode.java
@@ -2,7 +2,8 @@ package ikarabulut.http.response;
 
 public enum StatusCode {
     OK("OK" , "200"),
-    NOT_ALLOWED("NOT ALLOWED", "405");
+    NOT_ALLOWED("NOT ALLOWED", "405"),
+    NOT_FOUND("PAGE NOT FOUND", "404");
 
     final String code;
     final String number;

--- a/app/src/main/java/ikarabulut/http/server/Router.java
+++ b/app/src/main/java/ikarabulut/http/server/Router.java
@@ -1,9 +1,6 @@
 package ikarabulut.http.server;
 
-import ikarabulut.http.handlers.GetRequestHandler;
-import ikarabulut.http.handlers.HeadRequestHandler;
-import ikarabulut.http.handlers.MethodNotAllowedHandler;
-import ikarabulut.http.handlers.PostRequestHandler;
+import ikarabulut.http.handlers.*;
 import ikarabulut.http.parser.RequestParser;
 import ikarabulut.http.response.Response;
 
@@ -32,7 +29,7 @@ public class Router {
     public Response routeRequest() {
 
         if (!resourceExists()) {
-            runPageNotFound();
+            return runPageNotFound();
         } else if(!pathIncludesMethod()) {
             return methodNotAllowed(pathsIncludedMethods());
         }
@@ -72,8 +69,9 @@ public class Router {
         return requestHandler.processResponse();
     }
 
-    public void runPageNotFound(){
-
+    public Response runPageNotFound(){
+        PageNotFoundHandler requestHandler = new PageNotFoundHandler(rawRequest);
+        return null; //TEMPORARY
     }
 
     private boolean pathIncludesMethod() {

--- a/app/src/main/java/ikarabulut/http/server/Router.java
+++ b/app/src/main/java/ikarabulut/http/server/Router.java
@@ -71,7 +71,7 @@ public class Router {
 
     public Response runPageNotFound(){
         PageNotFoundHandler requestHandler = new PageNotFoundHandler(rawRequest);
-        return null; //TEMPORARY
+        return requestHandler.processResponse();
     }
 
     private boolean pathIncludesMethod() {

--- a/app/src/main/java/ikarabulut/http/server/Router.java
+++ b/app/src/main/java/ikarabulut/http/server/Router.java
@@ -31,7 +31,9 @@ public class Router {
 
     public Response routeRequest() {
 
-        if (!pathIncludesMethod()) {
+        if (!resourceExists()) {
+            runPageNotFound();
+        } else if(!pathIncludesMethod()) {
             return methodNotAllowed(pathsIncludedMethods());
         }
 
@@ -70,6 +72,10 @@ public class Router {
         return requestHandler.processResponse();
     }
 
+    public void runPageNotFound(){
+
+    }
+
     private boolean pathIncludesMethod() {
         initialLine = rawRequest.parseInitialLine();
         String method = initialLine.get("httpMethod");
@@ -81,6 +87,12 @@ public class Router {
         initialLine = rawRequest.parseInitialLine();
         String path = initialLine.get("httpPath");
         return paths.get(path);
+    }
+
+    private boolean resourceExists() {
+        initialLine = rawRequest.parseInitialLine();
+        String resource = initialLine.get("httpPath");
+        return paths.containsKey(resource);
     }
 
 }

--- a/app/src/test/java/ikarabulut/http/handlers/PageNotFoundHandlerTest.java
+++ b/app/src/test/java/ikarabulut/http/handlers/PageNotFoundHandlerTest.java
@@ -1,0 +1,15 @@
+package ikarabulut.http.handlers;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PageNotFoundHandlerTest {
+    @Test
+    @DisplayName("PageNotFound should process a response with a 404 status code")
+    void processResponse_ShouldHave404() {
+
+    }
+
+}

--- a/app/src/test/java/ikarabulut/http/response/PageNotFoundResponseTest.java
+++ b/app/src/test/java/ikarabulut/http/response/PageNotFoundResponseTest.java
@@ -1,4 +1,23 @@
+package ikarabulut.http.response;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.*;
+
 class PageNotFoundResponseTest {
-  
+    private String version = "HTTP/1.1";
+    private StatusCode status = StatusCode.NOT_FOUND;
+
+    @Test
+    @DisplayName("A Response should be generated with a 405 code and PAGE NOT FOUND code")
+    void stringifyResponse_ShouldHave404() {
+        Response response = new PageNotFoundResponse(version, status);
+
+        String receivedResponse = response.stringifyResponse();
+
+        assertTrue(receivedResponse.contains("PAGE NOT FOUND"));
+        assertTrue(receivedResponse.contains("404"));
+    }
+
 }

--- a/app/src/test/java/ikarabulut/http/response/PageNotFoundResponseTest.java
+++ b/app/src/test/java/ikarabulut/http/response/PageNotFoundResponseTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class PageNotFoundResponseTest {
+  
+}

--- a/app/src/test/java/ikarabulut/http/server/RouterTest.java
+++ b/app/src/test/java/ikarabulut/http/server/RouterTest.java
@@ -79,4 +79,19 @@ class RouterTest {
         Mockito.verify(spyRouter).runPostRequest();
     }
 
+    @Test
+    @DisplayName("When a request includes an unconfigured resource then runPageNotFound should be called")
+    void routeRequest_PageNotFound() {
+        RequestParser parsedRequest = mock(RequestParser.class);
+        initialLine.put("httpMethod", "POST");
+        initialLine.put("httpPath", "/unconfigured_resource");
+        initialLine.put("httpVersion", "HTTP/1.1");
+        when(parsedRequest.parseInitialLine()).thenReturn(initialLine);
+        Router router = new Router(parsedRequest);
+        Router spyRouter = Mockito.spy(router);
+
+        spyRouter.routeRequest();
+
+        Mockito.verify(spyRouter).runPageNotFound();
+    }
 }

--- a/http_server_spec/features/01_getting_started/page_not_found.feature
+++ b/http_server_spec/features/01_getting_started/page_not_found.feature
@@ -1,6 +1,5 @@
 @page-not-found @01-getting-started
 Feature: Page Not Found
-  @wip
   Scenario: Getting an unconfigured resource returns a 404
     Given I make a GET request to a page that does not exist
     Then my response should have status code 404


### PR DESCRIPTION
The following PR is for [page_not_found story](https://trello.com/c/sxyIJxAF) and passes the [http_server_spec page not found acceptance test](https://github.com/8thlight/http_server_spec/blob/master/features/01_getting_started/page_not_found.feature)

Server additions
- 404 Code added to `StatusCode` that can now be used throughout the program
- `Router` now first checks to ensure a resource is configured, if not it will trigger the new `PageNotFoundRequestHandler` method sending the client to that handler and then will process a Response based on the `PageNotFoundResponse` implementation criteria

The overall strategy here was to build upon the current architecture of the server. Improvements that can be considered is a cleaner approach to `routeRequest` instead of having three conditional gates the client has to go through. Also, the server overall has a lot of hardcoded responses and the Class names do not truly represent what they can do. An example would be with `PageNotFoundRequestHandler` where when it processes a response `processResponse` it has the body of the request hardcoded to be then passed as the body of the response which constrains that class to only do that one thing.